### PR TITLE
CI: Latest Ruby versions; default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
-  - 2.3
+  - "3.0"
+  - "2.7"
+  - "2.6"
 before_install:
   - gem install bundler

--- a/README.md
+++ b/README.md
@@ -45,31 +45,31 @@ user.other = "2001-01-01"
 user.other # => "2001-01-01"
 ```
 
-## Custom FactoryGirl strategy
+## Custom FactoryBot strategy
 
-Add this to your spec_helper after loading FactoryGirl:
+Add this to your spec_helper after loading FactoryBot:
 
 ```ruby
-require "minimapper/factory_girl"
+require "minimapper/factory_bot"
 ```
 
-It changes the create strategy used by FactoryGirl to make it compatible with minimapper.
+It changes the create strategy used by FactoryBot to make it compatible with minimapper.
 
-So far it only supports saving single entities and belongs_to associations.
+So far it only supports saving single entities and `belongs_to` associations.
 
 It assumes you can access your mappers though something like "Repository.employees". You can override that by
 changing `CreateThroughRepositoryStrategy::Create#mapper_with_name`.
 
-It also assumes the model has accessors for related objects, we use the "minimapper/entity/belongs_to" to do this.
+It also assumes the model has accessors for related objects, we use the `minimapper/entity/belongs_to` to do this.
 
 Example factory definition:
 
 ```ruby
 require "customer"
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :order do
-    customer { FactoryGirl.build(:customer) }
+    customer { FactoryBot.build(:customer) }
     description "ref. 123"
   end
 end

--- a/lib/minimapper/entity/serialized_association.rb
+++ b/lib/minimapper/entity/serialized_association.rb
@@ -1,6 +1,4 @@
 require "minimapper/entity"
-require "backports/1.9.1/kernel/public_send"
-require "backports/1.8.7/kernel/instance_exec"
 
 module Minimapper
   module Entity

--- a/lib/minimapper/factory_bot.rb
+++ b/lib/minimapper/factory_bot.rb
@@ -1,5 +1,4 @@
 require "attr_extras"
-require "backports/1.9.1/kernel/public_send"
 
 class CreateThroughRepositoryStrategy
   def result(evaluation)
@@ -17,7 +16,7 @@ class CreateThroughRepositoryStrategy
 
       # Recursively creates all dependencies of this entity before
       # going on to the the entity itself. This is here so that we can do
-      # "customer { FactoryGirl.build(:customer) }" in factories.
+      # "customer { FactoryBot.build(:customer) }" in factories.
       create_dependencies
 
       if entity.persisted?
@@ -54,4 +53,4 @@ class CreateThroughRepositoryStrategy
   end
 end
 
-FactoryGirl.register_strategy(:create, CreateThroughRepositoryStrategy)
+FactoryBot.register_strategy(:create, CreateThroughRepositoryStrategy)

--- a/lib/minimapper/mapper/has_many_association.rb
+++ b/lib/minimapper/mapper/has_many_association.rb
@@ -1,5 +1,4 @@
 require "attr_extras"
-require "backports/1.9.1/kernel/public_send"
 
 # Mapping of associated entity changes. Creates when not persisted, updates
 # when persisted and removes when it has been removed from the in-memory model.

--- a/minimapper-extras.gemspec
+++ b/minimapper-extras.gemspec
@@ -18,13 +18,11 @@ Gem::Specification.new do |spec|
     spec.files         = `git ls-files`.split($/)
   end
 
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "minimapper", ">= 0.8"
   spec.add_dependency "attr_extras"
-  spec.add_dependency "backports"
   spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/spec/minimapper/factory_bot_spec.rb
+++ b/spec/minimapper/factory_bot_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-FactoryGirl = Class.new do
+FactoryBot = Class.new do
   def self.register_strategy(name, klass)
   end
 end
 
 Repository = Class.new
 
-require "minimapper/factory_girl"
+require "minimapper/factory_bot"
 require "minimapper/entity"
 require "minimapper/entity/belongs_to"
 
@@ -32,8 +32,8 @@ end
 
 describe CreateThroughRepositoryStrategy do
   let(:entity) { Location.new }
-  let(:location_mapper) { double }
-  let(:evaluation) { double(object: entity) }
+  let(:location_mapper) { double(:location_mapper) }
+  let(:evaluation) { double(:evaluation, object: entity) }
 
   before do
     allow(Repository).to receive(:locations).and_return(location_mapper)
@@ -54,8 +54,8 @@ describe CreateThroughRepositoryStrategy do
 end
 
 describe CreateThroughRepositoryStrategy, "when there are belongs_to associations" do
-  let(:payment_mapper) { double }
-  let(:order_mapper) { double }
+  let(:payment_mapper) { double(:payment_mapper) }
+  let(:order_mapper) { double(:order_mapper) }
 
   before do
     allow(Repository).to receive(:orders).and_return(order_mapper)
@@ -83,7 +83,7 @@ describe CreateThroughRepositoryStrategy, "when there are belongs_to association
     order = Order.new(payment: payment)
     expect(payment_mapper).not_to receive(:create)
     expect(order_mapper).to receive(:create).ordered.with(order).and_return(true)
-    evaluation = double(object: order)
+    evaluation = double(:evaluation, object: order)
     CreateThroughRepositoryStrategy.new.result(evaluation)
   end
 end


### PR DESCRIPTION
This PR updates the CI matrix to use in-support Ruby versions, and rely on "default rake task" as Travis build script.

- CI config
- Spec: Avoid a BigDecimal.new method access
- Use the name FactoryBot
- Spec: name doubles
- Gemspec: Exclude `backports` gem, not needed
- CI: Install a new-enough Bundler

## TODO

- fix 2 failing tests